### PR TITLE
fix: correct typos in concurrency article

### DIFF
--- a/content/concurrency.article
+++ b/content/concurrency.article
@@ -17,9 +17,8 @@ _goroutine_ 은 Go 런타임에 의해 관리되는 경량 쓰레드입니다.
 f와 x, y, z의 evaluation은 현재의 goroutine에서 일어나고, `f` 의 실행은 새로운 goroutine에서 일어납니다.
 
 goroutine은 같은 주소의 공간에서 실행되고, 따라서 공유된 메모리는 synchronous(동기적) 해야합니다.
-Go에 다른 기본형들이 존재하는 것처 당신이 Go에서 sync와 관련된 기본 기능이 필요없다하더라도 [[https://golang.org/pkg/sync/][`sync`]] 패키지는 유용한 기본형을 제공합니다.
+Go에 다른 기본형들이 존재하므로 당신이 Go에서 sync와 관련된 기본 기능이 필요없다하더라도 [[https://golang.org/pkg/sync/][`sync`]] 패키지는 유용한 기본형을 제공합니다.
 (다음 페이지에서 자세히 확인해보십시오.)
-goroutine은 같은 주소 공간에서 실행되고 따라서 공유된 메모리에 대한 접근은 synchronous(동기적) 해야만합니다.
 
 
 .play concurrency/goroutines.go
@@ -120,7 +119,7 @@ block 없이 전송이나 수신을 수행하도록 `default` case를 사용해�
 		Right *Tree
 	}
 
-[[javascript:click('.next-page')][다음 페이지]]에서 설명 계속 보.
+[[javascript:click('.next-page')][다음 페이지]]에 설명이 이어집니다.
 
 * 실습: 동일한 이진 트리
 


### PR DESCRIPTION
동일한 문장이 반복되는 것과 어색한 문장을 수정했습니다.

원문은 아래와 같습니다.

1.  
```
Goroutines run in the same address space, so access to shared memory must be synchronized. The sync package provides useful primitives, although you won't need them much in Go as there are other primitives. 
```

2. 
```
Continue description on next page.
```
